### PR TITLE
Add session limits and timeout handling in orchestrator

### DIFF
--- a/admin/main.py
+++ b/admin/main.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
 from fastapi import Depends, FastAPI, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette import status as http_status
 
 from admin.api import api_router
 from core.config import get_settings
 from core.db import AsyncSessionLocal, get_session
 from core.models import Personality, Provider, Session, Setting
-from orchestrator.service import DialogueOrchestrator
+from orchestrator.service import (
+    DialogueOrchestrator,
+    SESSION_LIMIT_SETTING_CASTERS,
+    set_setting,
+)
 
 app = FastAPI(title="Roundtable AI")
 app.include_router(api_router)
@@ -61,7 +66,31 @@ async def admin_sessions(request: Request, db: AsyncSession = Depends(get_sessio
 async def admin_settings(request: Request, db: AsyncSession = Depends(get_session)) -> HTMLResponse:
     result = await db.execute(select(Setting))
     settings = result.scalars().all()
-    return templates.TemplateResponse("settings.html", {"request": request, "title": "Настройки", "settings": settings})
+    settings_map = {item.key: item.value for item in settings}
+    runtime_settings = get_settings()
+    limit_values = {
+        key: settings_map.get(key, str(getattr(runtime_settings, key)))
+        for key in SESSION_LIMIT_SETTING_CASTERS.keys()
+    }
+    context = {
+        "request": request,
+        "title": "Настройки",
+        "settings": settings,
+        "limit_values": limit_values,
+    }
+    return templates.TemplateResponse("settings.html", context)
+
+
+@app.post("/admin/settings/limits", response_class=HTMLResponse)
+async def update_limits(request: Request, db: AsyncSession = Depends(get_session)) -> RedirectResponse:
+    form = await request.form()
+    for key in SESSION_LIMIT_SETTING_CASTERS.keys():
+        value = form.get(key)
+        if value is None or value == "":
+            continue
+        await set_setting(db, key, value)
+    await db.commit()
+    return RedirectResponse(url="/admin/settings", status_code=http_status.HTTP_303_SEE_OTHER)
 
 
 @app.on_event("startup")

--- a/admin/templates/settings.html
+++ b/admin/templates/settings.html
@@ -1,6 +1,34 @@
 {% extends "base.html" %}
 {% block content %}
 <h1 class="title">Настройки</h1>
+<div class="box">
+    <h2 class="subtitle">Лимиты сессии</h2>
+    <form method="post" action="/admin/settings/limits">
+        <div class="field">
+            <label class="label">Лимит токенов входящих сообщений</label>
+            <div class="control">
+                <input class="input" type="number" min="0" name="session_tokens_in_limit" value="{{ limit_values.session_tokens_in_limit }}" required>
+            </div>
+        </div>
+        <div class="field">
+            <label class="label">Лимит токенов ответов</label>
+            <div class="control">
+                <input class="input" type="number" min="0" name="session_tokens_out_limit" value="{{ limit_values.session_tokens_out_limit }}" required>
+            </div>
+        </div>
+        <div class="field">
+            <label class="label">Лимит стоимости (USD)</label>
+            <div class="control">
+                <input class="input" type="number" min="0" step="0.01" name="session_cost_limit" value="{{ limit_values.session_cost_limit }}" required>
+            </div>
+        </div>
+        <div class="field is-grouped">
+            <div class="control">
+                <button class="button is-primary" type="submit">Сохранить</button>
+            </div>
+        </div>
+    </form>
+</div>
 <table class="table is-fullwidth">
     <thead>
     <tr>

--- a/core/config.py
+++ b/core/config.py
@@ -15,6 +15,9 @@ class Settings(BaseSettings):
     max_rounds: int = 5
     turn_timeout_sec: int = 60
     context_token_limit: int = 6000
+    session_tokens_in_limit: int = 60000
+    session_tokens_out_limit: int = 60000
+    session_cost_limit: float = 100.0
     payment_url: AnyHttpUrl
     openai_api_key: str
     openai_model: str = "gpt-4o-mini"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -5,7 +5,9 @@ from dataclasses import dataclass
 
 import pytest
 
-from core.models import Personality, Provider, Session, SessionParticipant, User
+from sqlalchemy import select
+
+from core.models import AuditLog, Personality, Provider, Session, SessionParticipant, User
 from core.security import SecretsManager
 from orchestrator.service import DialogueOrchestrator
 
@@ -14,6 +16,10 @@ from orchestrator.service import DialogueOrchestrator
 class DummySettings:
     max_rounds: int = 2
     context_token_limit: int = 2000
+    turn_timeout_sec: int = 60
+    session_tokens_in_limit: int = 60000
+    session_tokens_out_limit: int = 60000
+    session_cost_limit: float = 100.0
 
     @property
     def payment_url(self) -> str:
@@ -27,6 +33,12 @@ class StubAdapter:
     async def complete(self, prompt: str, context):
         self.counter += 1
         return f"Ответ {self.counter}", {"prompt_tokens": 5, "completion_tokens": 5, "cost": 0.001}
+
+
+class SlowAdapter(StubAdapter):
+    async def complete(self, prompt: str, context):
+        await asyncio.sleep(1.1)
+        return await super().complete(prompt, context)
 
 
 @pytest.mark.asyncio
@@ -68,3 +80,85 @@ async def test_orchestrator_runs_rounds(monkeypatch, db_session):
     assert len(rows) > 0
     messages = stored_session.messages
     assert any(msg.author_name.startswith("OpenAI") for msg in messages)
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_stops_on_limits(monkeypatch, db_session):
+    secrets = SecretsManager()
+    provider = Provider(
+        name="OpenAI",
+        type="openai",
+        api_key_encrypted=secrets.encrypt("key"),
+        model_id="gpt",
+        parameters={},
+        enabled=True,
+        order_index=0,
+    )
+    personality = Personality(title="Expert", instructions="Будь аналитиком", style="Сдержанный")
+    user = User(telegram_id=456, username="limits")
+    db_session.add_all([provider, personality, user])
+    await db_session.commit()
+
+    stub_adapter = StubAdapter()
+
+    def adapter_factory(provider_type, api_key, model, **params):
+        return stub_adapter
+
+    monkeypatch.setattr("orchestrator.service.create_adapter", adapter_factory)
+
+    settings = DummySettings(
+        session_tokens_in_limit=6,
+        session_tokens_out_limit=5,
+        session_cost_limit=0.001,
+    )
+    orchestrator = DialogueOrchestrator(db_session, settings=settings, secrets=secrets)
+    session = await orchestrator.create_session(user_id=456, topic="Лимиты", max_rounds=3)
+    await db_session.commit()
+
+    await orchestrator.start_session(session.id)
+    await db_session.commit()
+
+    stored_session = await db_session.get(Session, session.id)
+    assert stored_session.status == "stopped"
+    audit_logs = (await db_session.execute(select(AuditLog))).scalars().all()
+    assert any(log.action == "session_limit_reached" for log in audit_logs)
+    limit_log = next(log for log in audit_logs if log.action == "session_limit_reached")
+    assert limit_log.meta.get("limit_type") in {"tokens_in", "tokens_out", "cost"}
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_timeout_stops_session(monkeypatch, db_session):
+    secrets = SecretsManager()
+    provider = Provider(
+        name="OpenAI",
+        type="openai",
+        api_key_encrypted=secrets.encrypt("key"),
+        model_id="gpt",
+        parameters={},
+        enabled=True,
+        order_index=0,
+    )
+    personality = Personality(title="Expert", instructions="Будь аналитиком", style="Сдержанный")
+    user = User(telegram_id=789, username="timeout")
+    db_session.add_all([provider, personality, user])
+    await db_session.commit()
+
+    slow_adapter = SlowAdapter()
+
+    def adapter_factory(provider_type, api_key, model, **params):
+        return slow_adapter
+
+    monkeypatch.setattr("orchestrator.service.create_adapter", adapter_factory)
+
+    settings = DummySettings(turn_timeout_sec=1)
+    orchestrator = DialogueOrchestrator(db_session, settings=settings, secrets=secrets)
+    session = await orchestrator.create_session(user_id=789, topic="Таймаут", max_rounds=3)
+    await db_session.commit()
+
+    await orchestrator.start_session(session.id)
+    await db_session.commit()
+
+    stored_session = await db_session.get(Session, session.id)
+    assert stored_session.status == "stopped"
+    audit_logs = (await db_session.execute(select(AuditLog))).scalars().all()
+    assert any(log.action == "session_timeout" for log in audit_logs)


### PR DESCRIPTION
## Summary
- stop dialogue rounds when they exceed the configured timeout and record the reason
- enforce per-session token and cost limits configurable via settings and expose controls in the admin UI
- extend orchestrator tests to cover limit and timeout scenarios

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd840d257c8326a0d9ab4f470dba49