### PR TITLE
Run sessions asynchronously and respect stop requests

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,6 +37,68 @@ async def test_full_session_flow(monkeypatch):
 
     monkeypatch.setattr(service_module, "create_adapter", adapter_factory)
 
+    import worker.tasks as worker_tasks
+
+    scheduled: list[int] = []
+
+    monkeypatch.setattr(worker_tasks.run_session, "delay", lambda session_id: scheduled.append(session_id))
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        provider_payload = {
+            "name": "OpenAI Stop",
+            "type": "openai",
+            "api_key": "key",
+            "model_id": "gpt",
+            "parameters": {},
+            "enabled": True,
+            "order_index": 0,
+        }
+        response = await client.post("/api/providers", json=provider_payload)
+        assert response.status_code == 201
+
+        personality_payload = {"title": "Moderator", "instructions": "Будь модератором", "style": "Формально"}
+        response = await client.post("/api/personalities", json=personality_payload)
+        assert response.status_code == 201
+
+        response = await client.post("/api/users", json={"telegram_id": 1, "username": "tester"})
+        assert response.status_code == 201
+
+        session_payload = {"user_id": 1, "topic": "ИИ в образовании", "max_rounds": 1}
+        response = await client.post("/api/sessions", json=session_payload)
+        assert response.status_code == 201
+        session_id = response.json()["id"]
+
+        response = await client.post(f"/api/sessions/{session_id}/start")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] in {"running", "finished", "stopped"}
+        assert scheduled == [session_id]
+
+        async with core_db.AsyncSessionLocal() as session:
+            orchestrator = service_module.DialogueOrchestrator(session)
+            await orchestrator.run_session(session_id)
+            await session.commit()
+
+        response = await client.get(f"/api/sessions/{session_id}")
+        assert response.status_code == 200
+        assert response.json()["id"] == session_id
+        assert response.json()["status"] == "finished"
+
+
+@pytest.mark.asyncio
+async def test_stop_session_via_api(monkeypatch):
+    stub = ApiStubAdapter()
+
+    def adapter_factory(provider_type, api_key, model, **params):
+        return stub
+
+    monkeypatch.setattr(service_module, "create_adapter", adapter_factory)
+
+    import worker.tasks as worker_tasks
+
+    monkeypatch.setattr(worker_tasks.run_session, "delay", lambda session_id: None)
+
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         provider_payload = {
@@ -55,19 +117,27 @@ async def test_full_session_flow(monkeypatch):
         response = await client.post("/api/personalities", json=personality_payload)
         assert response.status_code == 201
 
-        response = await client.post("/api/users", json={"telegram_id": 1, "username": "tester"})
+        response = await client.post("/api/users", json={"telegram_id": 2, "username": "stopper"})
         assert response.status_code == 201
 
-        session_payload = {"user_id": 1, "topic": "ИИ в образовании", "max_rounds": 1}
+        session_payload = {"user_id": 2, "topic": "ИИ и этика", "max_rounds": 2}
         response = await client.post("/api/sessions", json=session_payload)
         assert response.status_code == 201
         session_id = response.json()["id"]
 
         response = await client.post(f"/api/sessions/{session_id}/start")
         assert response.status_code == 200
-        data = response.json()
-        assert data["status"] in {"running", "finished", "stopped"}
+        assert response.json()["status"] == "running"
+
+        response = await client.post(f"/api/sessions/{session_id}/stop")
+        assert response.status_code == 200
+        assert response.json()["status"] == "stopped"
+
+        async with core_db.AsyncSessionLocal() as session:
+            orchestrator = service_module.DialogueOrchestrator(session)
+            await orchestrator.run_session(session_id)
+            await session.commit()
 
         response = await client.get(f"/api/sessions/{session_id}")
         assert response.status_code == 200
-        assert response.json()["id"] == session_id
+        assert response.json()["status"] == "stopped"

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -14,7 +14,7 @@ def run_session(session_id: int) -> None:
     async def _run() -> None:
         async with AsyncSessionLocal() as db:
             orchestrator = DialogueOrchestrator(db, settings=settings)
-            await orchestrator.start_session(session_id)
+            await orchestrator.run_session(session_id)
             await db.commit()
 
     import asyncio


### PR DESCRIPTION
## Summary
- dispatch session execution to Celery and add explicit run_session handling with stop-aware dialogue loop
- update Telegram bot handlers to keep session state until completion and report stopped sessions to users
- cover background start/stop flows with orchestrator and API tests

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd8407e1048326bcd204ee18d3c300