### PR TITLE
Add admin CRUD forms for providers, personalities, and settings

### DIFF
--- a/admin/main.py
+++ b/admin/main.py
@@ -1,12 +1,26 @@
 from __future__ import annotations
 
-from fastapi import Depends, FastAPI, Request
-from fastapi.responses import HTMLResponse
+import json
+
+from fastapi import Depends, FastAPI, Form, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from admin.api import api_router
+from admin.api import (
+    ProviderBase,
+    PersonalityBase,
+    SettingUpdate,
+    api_router,
+    create_personality,
+    create_provider,
+    delete_personality,
+    delete_provider,
+    set_setting_api,
+    update_personality,
+    update_provider,
+)
 from core.config import get_settings
 from core.db import AsyncSessionLocal, get_session
 from core.models import Personality, Provider, Session, Setting
@@ -43,11 +57,115 @@ async def admin_providers(request: Request, db: AsyncSession = Depends(get_sessi
     return templates.TemplateResponse("providers.html", {"request": request, "title": "Провайдеры", "providers": providers})
 
 
+def _parse_bool(value: str | None) -> bool:
+    return value not in (None, "", "0", "false", "False", "off")
+
+
+def _parse_parameters(raw: str | None) -> dict:
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+        if not isinstance(parsed, dict):
+            raise ValueError("Parameters must be a JSON object")
+        return parsed
+    except json.JSONDecodeError as exc:  # pragma: no cover - validation branch
+        raise HTTPException(status_code=400, detail=f"Некорректный JSON параметров: {exc.msg}") from exc
+    except ValueError as exc:  # pragma: no cover - validation branch
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.post("/admin/providers")
+async def create_provider_form(
+    name: str = Form(...),
+    type: str = Form(...),
+    api_key: str = Form(...),
+    model_id: str = Form(...),
+    parameters: str | None = Form(default=None),
+    enabled: str | None = Form(default=None),
+    order_index: int = Form(default=0),
+    db: AsyncSession = Depends(get_session),
+):
+    payload = ProviderBase(
+        name=name,
+        type=type,
+        api_key=api_key,
+        model_id=model_id,
+        parameters=_parse_parameters(parameters),
+        enabled=_parse_bool(enabled),
+        order_index=order_index,
+    )
+    await create_provider(payload, db)
+    return RedirectResponse("/admin/providers", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.put("/admin/providers/{provider_id}")
+async def update_provider_form(
+    provider_id: int,
+    name: str = Form(...),
+    type: str = Form(...),
+    api_key: str = Form(...),
+    model_id: str = Form(...),
+    parameters: str | None = Form(default=None),
+    enabled: str | None = Form(default=None),
+    order_index: int = Form(default=0),
+    db: AsyncSession = Depends(get_session),
+):
+    payload = ProviderBase(
+        name=name,
+        type=type,
+        api_key=api_key,
+        model_id=model_id,
+        parameters=_parse_parameters(parameters),
+        enabled=_parse_bool(enabled),
+        order_index=order_index,
+    )
+    await update_provider(provider_id, payload, db)
+    return RedirectResponse("/admin/providers", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.delete("/admin/providers/{provider_id}")
+async def delete_provider_form(provider_id: int, db: AsyncSession = Depends(get_session)):
+    await delete_provider(provider_id, db)
+    return RedirectResponse("/admin/providers", status_code=status.HTTP_303_SEE_OTHER)
+
+
 @app.get("/admin/personalities", response_class=HTMLResponse)
 async def admin_personalities(request: Request, db: AsyncSession = Depends(get_session)) -> HTMLResponse:
     result = await db.execute(select(Personality).order_by(Personality.title))
     personalities = result.scalars().all()
     return templates.TemplateResponse("personalities.html", {"request": request, "title": "Персоналии", "personalities": personalities})
+
+
+@app.post("/admin/personalities")
+async def create_personality_form(
+    title: str = Form(...),
+    instructions: str = Form(...),
+    style: str | None = Form(default=None),
+    db: AsyncSession = Depends(get_session),
+):
+    payload = PersonalityBase(title=title, instructions=instructions, style=style or None)
+    await create_personality(payload, db)
+    return RedirectResponse("/admin/personalities", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.put("/admin/personalities/{personality_id}")
+async def update_personality_form(
+    personality_id: int,
+    title: str = Form(...),
+    instructions: str = Form(...),
+    style: str | None = Form(default=None),
+    db: AsyncSession = Depends(get_session),
+):
+    payload = PersonalityBase(title=title, instructions=instructions, style=style or None)
+    await update_personality(personality_id, payload, db)
+    return RedirectResponse("/admin/personalities", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.delete("/admin/personalities/{personality_id}")
+async def delete_personality_form(personality_id: int, db: AsyncSession = Depends(get_session)):
+    await delete_personality(personality_id, db)
+    return RedirectResponse("/admin/personalities", status_code=status.HTTP_303_SEE_OTHER)
 
 
 @app.get("/admin/sessions", response_class=HTMLResponse)
@@ -62,6 +180,36 @@ async def admin_settings(request: Request, db: AsyncSession = Depends(get_sessio
     result = await db.execute(select(Setting))
     settings = result.scalars().all()
     return templates.TemplateResponse("settings.html", {"request": request, "title": "Настройки", "settings": settings})
+
+
+@app.post("/admin/settings")
+async def create_setting_form(
+    key: str = Form(...),
+    value: str = Form(...),
+    db: AsyncSession = Depends(get_session),
+):
+    await set_setting_api(key, SettingUpdate(value=value), db)
+    return RedirectResponse("/admin/settings", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.put("/admin/settings/{key}")
+async def update_setting_form(
+    key: str,
+    value: str = Form(...),
+    db: AsyncSession = Depends(get_session),
+):
+    await set_setting_api(key, SettingUpdate(value=value), db)
+    return RedirectResponse("/admin/settings", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.delete("/admin/settings/{key}")
+async def delete_setting_form(key: str, db: AsyncSession = Depends(get_session)):
+    setting = await db.get(Setting, key)
+    if not setting:
+        raise HTTPException(status_code=404, detail="Setting not found")
+    await db.delete(setting)
+    await db.commit()
+    return RedirectResponse("/admin/settings", status_code=status.HTTP_303_SEE_OTHER)
 
 
 @app.on_event("startup")

--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -24,5 +24,54 @@
         {% block content %}{% endblock %}
     </div>
 </section>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('form[data-method]').forEach((form) => {
+        form.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            const method = (form.dataset.method || 'post').toUpperCase();
+            const action = form.getAttribute('action');
+            const redirectUrl = form.dataset.redirect || window.location.pathname;
+            const formData = new FormData(form);
+            const response = await fetch(action, {
+                method,
+                body: formData,
+            });
+            if (response.ok) {
+                if (response.redirected) {
+                    window.location.href = response.url;
+                } else {
+                    window.location.href = redirectUrl;
+                }
+            } else {
+                const text = await response.text();
+                alert(`Ошибка ${response.status}: ${text}`);
+            }
+        });
+    });
+
+    document.querySelectorAll('[data-delete]').forEach((element) => {
+        element.addEventListener('click', async (event) => {
+            event.preventDefault();
+            if (!confirm('Удалить запись?')) {
+                return;
+            }
+            const url = element.dataset.delete;
+            const redirectUrl = element.dataset.redirect || window.location.pathname;
+            const response = await fetch(url, { method: 'DELETE' });
+            if (response.ok) {
+                if (response.redirected) {
+                    window.location.href = response.url;
+                } else {
+                    window.location.href = redirectUrl;
+                }
+            } else {
+                const text = await response.text();
+                alert(`Ошибка ${response.status}: ${text}`);
+            }
+        });
+    });
+});
+</script>
 </body>
 </html>

--- a/admin/templates/personalities.html
+++ b/admin/templates/personalities.html
@@ -1,6 +1,36 @@
 {% extends "base.html" %}
 {% block content %}
 <h1 class="title">Персоналии</h1>
+
+<div class="box">
+    <h2 class="title is-4">Добавить персоналию</h2>
+    <form method="post" action="/admin/personalities">
+        <div class="field">
+            <label class="label">Название</label>
+            <div class="control">
+                <input class="input" name="title" required>
+            </div>
+        </div>
+        <div class="field">
+            <label class="label">Инструкции</label>
+            <div class="control">
+                <textarea class="textarea" name="instructions" required></textarea>
+            </div>
+        </div>
+        <div class="field">
+            <label class="label">Стиль</label>
+            <div class="control">
+                <textarea class="textarea" name="style"></textarea>
+            </div>
+        </div>
+        <div class="field is-grouped">
+            <div class="control">
+                <button class="button is-primary" type="submit">Создать</button>
+            </div>
+        </div>
+    </form>
+</div>
+
 <table class="table is-striped is-fullwidth">
     <thead>
     <tr>
@@ -8,17 +38,51 @@
         <th>Название</th>
         <th>Инструкции</th>
         <th>Стиль</th>
+        <th></th>
     </tr>
     </thead>
     <tbody>
     {% for personality in personalities %}
     <tr>
         <td>{{ personality.id }}</td>
-        <td>{{ personality.title }}</td>
-        <td>{{ personality.instructions }}</td>
-        <td>{{ personality.style }}</td>
+        <td colspan="4">
+            <form data-method="put" data-redirect="/admin/personalities" action="/admin/personalities/{{ personality.id }}">
+                <div class="columns">
+                    <div class="column is-4">
+                        <div class="field">
+                            <div class="control">
+                                <input class="input" name="title" value="{{ personality.title }}" required>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="column is-4">
+                        <div class="field">
+                            <div class="control">
+                                <textarea class="textarea" name="instructions" rows="4" required>{{ personality.instructions }}</textarea>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="column is-3">
+                        <div class="field">
+                            <div class="control">
+                                <textarea class="textarea" name="style" rows="4">{{ personality.style or '' }}</textarea>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="column is-1">
+                        <div class="buttons is-flex is-flex-direction-column">
+                            <button class="button is-link" type="submit">Сохранить</button>
+                            <button class="button is-danger is-light" type="button" data-delete="/admin/personalities/{{ personality.id }}" data-redirect="/admin/personalities">Удалить</button>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </td>
     </tr>
     {% endfor %}
     </tbody>
 </table>
+{% if not personalities %}
+<p>Персоналии пока не добавлены.</p>
+{% endif %}
 {% endblock %}

--- a/admin/templates/providers.html
+++ b/admin/templates/providers.html
@@ -1,28 +1,163 @@
 {% extends "base.html" %}
 {% block content %}
 <h1 class="title">Провайдеры</h1>
+
+<div class="box">
+    <h2 class="title is-4">Добавить провайдера</h2>
+    <form method="post" action="/admin/providers">
+        <div class="columns is-multiline">
+            <div class="column is-4">
+                <div class="field">
+                    <label class="label">Название</label>
+                    <div class="control">
+                        <input class="input" name="name" required>
+                    </div>
+                </div>
+            </div>
+            <div class="column is-4">
+                <div class="field">
+                    <label class="label">Тип</label>
+                    <div class="control">
+                        <input class="input" name="type" required>
+                    </div>
+                </div>
+            </div>
+            <div class="column is-4">
+                <div class="field">
+                    <label class="label">Модель</label>
+                    <div class="control">
+                        <input class="input" name="model_id" required>
+                    </div>
+                </div>
+            </div>
+            <div class="column is-6">
+                <div class="field">
+                    <label class="label">API ключ</label>
+                    <div class="control">
+                        <input class="input" name="api_key" required>
+                    </div>
+                </div>
+            </div>
+            <div class="column is-6">
+                <div class="field">
+                    <label class="label">Параметры (JSON)</label>
+                    <div class="control">
+                        <textarea class="textarea" name="parameters" placeholder="{}"></textarea>
+                    </div>
+                </div>
+            </div>
+            <div class="column is-3">
+                <div class="field">
+                    <label class="label">Порядок</label>
+                    <div class="control">
+                        <input class="input" type="number" name="order_index" value="0">
+                    </div>
+                </div>
+            </div>
+            <div class="column is-3">
+                <div class="field">
+                    <label class="checkbox" style="margin-top: 2rem;">
+                        <input type="checkbox" name="enabled" checked>
+                        Включен
+                    </label>
+                </div>
+            </div>
+            <div class="column is-12">
+                <div class="field is-grouped">
+                    <div class="control">
+                        <button class="button is-primary" type="submit">Создать</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
+</div>
+
 <table class="table is-striped is-fullwidth">
     <thead>
     <tr>
         <th>ID</th>
         <th>Название</th>
         <th>Тип</th>
-        <th>Model</th>
+        <th>Модель</th>
+        <th>Параметры</th>
         <th>Порядок</th>
-        <th>Вкл.</th>
+        <th>Включен</th>
+        <th></th>
     </tr>
     </thead>
     <tbody>
     {% for provider in providers %}
     <tr>
         <td>{{ provider.id }}</td>
-        <td>{{ provider.name }}</td>
-        <td>{{ provider.type }}</td>
-        <td>{{ provider.model_id }}</td>
-        <td>{{ provider.order_index }}</td>
-        <td>{{ provider.enabled }}</td>
+        <td colspan="7">
+            <form data-method="put" data-redirect="/admin/providers" action="/admin/providers/{{ provider.id }}">
+                <div class="columns is-multiline">
+                    <div class="column is-3">
+                        <div class="field">
+                            <div class="control">
+                                <input class="input" name="name" value="{{ provider.name }}" required>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="column is-2">
+                        <div class="field">
+                            <div class="control">
+                                <input class="input" name="type" value="{{ provider.type }}" required>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="column is-3">
+                        <div class="field">
+                            <div class="control">
+                                <input class="input" name="model_id" value="{{ provider.model_id }}" required>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="column is-4">
+                        <div class="field">
+                            <div class="control">
+                                <input class="input" name="api_key" placeholder="Введите новый ключ" required>
+                            </div>
+                            <p class="help">Ключ хранится в зашифрованном виде, укажите новое значение.</p>
+                        </div>
+                    </div>
+                    <div class="column is-6">
+                        <div class="field">
+                            <div class="control">
+                                <textarea class="textarea" name="parameters">{{ provider.parameters | tojson }}</textarea>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="column is-2">
+                        <div class="field">
+                            <div class="control">
+                                <input class="input" type="number" name="order_index" value="{{ provider.order_index }}">
+                            </div>
+                        </div>
+                    </div>
+                    <div class="column is-2">
+                        <div class="field">
+                            <label class="checkbox">
+                                <input type="checkbox" name="enabled" {% if provider.enabled %}checked{% endif %}>
+                                Включен
+                            </label>
+                        </div>
+                    </div>
+                    <div class="column is-2">
+                        <div class="buttons">
+                            <button class="button is-link" type="submit">Сохранить</button>
+                            <button class="button is-danger is-light" type="button" data-delete="/admin/providers/{{ provider.id }}" data-redirect="/admin/providers">Удалить</button>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </td>
     </tr>
     {% endfor %}
     </tbody>
 </table>
+{% if not providers %}
+<p>Провайдеры пока не добавлены.</p>
+{% endif %}
 {% endblock %}

--- a/admin/templates/settings.html
+++ b/admin/templates/settings.html
@@ -1,20 +1,70 @@
 {% extends "base.html" %}
 {% block content %}
 <h1 class="title">Настройки</h1>
+
+<div class="box">
+    <h2 class="title is-4">Добавить/обновить настройку</h2>
+    <form method="post" action="/admin/settings">
+        <div class="columns">
+            <div class="column is-4">
+                <div class="field">
+                    <label class="label">Ключ</label>
+                    <div class="control">
+                        <input class="input" name="key" placeholder="MAX_ROUNDS" required>
+                    </div>
+                </div>
+            </div>
+            <div class="column is-4">
+                <div class="field">
+                    <label class="label">Значение</label>
+                    <div class="control">
+                        <input class="input" name="value" required>
+                    </div>
+                </div>
+            </div>
+            <div class="column is-4">
+                <div class="field is-grouped" style="margin-top: 2rem;">
+                    <div class="control">
+                        <button class="button is-primary" type="submit">Сохранить</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
+</div>
+
 <table class="table is-fullwidth">
     <thead>
     <tr>
         <th>Ключ</th>
         <th>Значение</th>
+        <th></th>
     </tr>
     </thead>
     <tbody>
     {% for item in settings %}
     <tr>
         <td>{{ item.key }}</td>
-        <td>{{ item.value }}</td>
+        <td>
+            <form data-method="put" data-redirect="/admin/settings" action="/admin/settings/{{ item.key }}">
+                <div class="field has-addons">
+                    <div class="control is-expanded">
+                        <input class="input" name="value" value="{{ item.value }}" required>
+                    </div>
+                    <div class="control">
+                        <button class="button is-link" type="submit">Обновить</button>
+                    </div>
+                </div>
+            </form>
+        </td>
+        <td class="has-text-right">
+            <button class="button is-danger is-light" type="button" data-delete="/admin/settings/{{ item.key }}" data-redirect="/admin/settings">Удалить</button>
+        </td>
     </tr>
     {% endfor %}
     </tbody>
 </table>
+{% if not settings %}
+<p>Настройки не заданы.</p>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- add FastAPI form handlers for creating, updating, and deleting providers, personalities, and settings in the admin module
- enrich providers, personalities, and settings templates with forms and delete controls that post to the new routes
- add a base template helper script to submit PUT/DELETE requests from HTML forms

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_68dd8367e8c483269048d752824023ac