### PR TITLE
Implement session detail APIs and improve bot discussion flow

### DIFF
--- a/admin/templates/session_detail.html
+++ b/admin/templates/session_detail.html
@@ -1,0 +1,62 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="title">Сессия #{{ session.id }}</h1>
+<div class="box">
+    <p><strong>Пользователь:</strong> {{ session.user_id }}</p>
+    <p><strong>Тема:</strong> {{ session.topic }}</p>
+    <p><strong>Статус:</strong> {{ session.status }}</p>
+    <p><strong>Раунды:</strong> {{ session.current_round }} / {{ session.max_rounds }}</p>
+    <p><strong>Создана:</strong> {{ session.created_at }}</p>
+    <p><strong>Завершена:</strong> {{ session.finished_at }}</p>
+    <p><strong>Всего токенов (in/out):</strong> {{ total_tokens_in }} / {{ total_tokens_out }}</p>
+    <p><strong>Суммарная стоимость:</strong> {{ '%.4f'|format(total_cost) }}</p>
+</div>
+
+<h2 class="subtitle">Участники</h2>
+<table class="table is-fullwidth is-striped">
+    <thead>
+    <tr>
+        <th>Порядок</th>
+        <th>Провайдер</th>
+        <th>Персоналия</th>
+        <th>Статус</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for participant in session.participants %}
+    <tr>
+        <td>{{ participant.order_index }}</td>
+        <td>{{ participant.provider_name }}</td>
+        <td>{{ participant.personality_title }}</td>
+        <td>{{ participant.status }}</td>
+    </tr>
+    {% endfor %}
+    </tbody>
+</table>
+
+<h2 class="subtitle">История сообщений</h2>
+<table class="table is-fullwidth is-hoverable">
+    <thead>
+    <tr>
+        <th>Время</th>
+        <th>Автор</th>
+        <th>Тип</th>
+        <th>Токены (in/out)</th>
+        <th>Стоимость</th>
+        <th>Текст</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for message in session.messages %}
+    <tr>
+        <td>{{ message.created_at }}</td>
+        <td>{{ message.author_name }}</td>
+        <td>{{ message.author_type }}</td>
+        <td>{{ message.tokens_in }} / {{ message.tokens_out }}</td>
+        <td>{{ '%.4f'|format(message.cost) }}</td>
+        <td style="white-space: pre-wrap;">{{ message.content }}</td>
+    </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/admin/templates/sessions.html
+++ b/admin/templates/sessions.html
@@ -15,7 +15,7 @@
     <tbody>
     {% for session in sessions %}
     <tr>
-        <td>{{ session.id }}</td>
+        <td><a href="/admin/sessions/{{ session.id }}">{{ session.id }}</a></td>
         <td>{{ session.user_id }}</td>
         <td>{{ session.topic }}</td>
         <td>{{ session.status }}</td>

--- a/core/config.py
+++ b/core/config.py
@@ -1,6 +1,6 @@
 from functools import lru_cache
-from pydantic_settings import BaseSettings
 from pydantic import AnyHttpUrl
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -21,10 +21,7 @@ class Settings(BaseSettings):
     deepseek_api_key: str
     deepseek_model: str = "deepseek-chat"
 
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
-        case_sensitive = False
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", case_sensitive=False)
 
     @property
     def database_url(self) -> str:

--- a/core/models.py
+++ b/core/models.py
@@ -112,6 +112,14 @@ class SessionParticipant(Base):
     provider: Mapped[Provider] = relationship("Provider", back_populates="participants")
     personality: Mapped[Personality] = relationship("Personality", back_populates="participants")
 
+    @property
+    def provider_name(self) -> str:
+        return self.provider.name if self.provider else ""
+
+    @property
+    def personality_title(self) -> str:
+        return self.personality.title if self.personality else ""
+
 
 class MessageAuthorType(str, PyEnum):
     USER = "user"

--- a/orchestrator/schemas.py
+++ b/orchestrator/schemas.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class MessageSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     author_type: str
     author_name: str
@@ -16,11 +18,10 @@ class MessageSchema(BaseModel):
     cost: float
     created_at: datetime
 
-    class Config:
-        orm_mode = True
-
 
 class SessionParticipantSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     provider_name: str
     personality_title: str
@@ -29,17 +30,18 @@ class SessionParticipantSchema(BaseModel):
 
 
 class SessionSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
+    user_id: int
     topic: str
     status: str
     created_at: datetime
     finished_at: Optional[datetime]
     max_rounds: int
     current_round: int
-    messages: list[MessageSchema]
-
-    class Config:
-        orm_mode = True
+    messages: list[MessageSchema] = Field(default_factory=list)
+    participants: list[SessionParticipantSchema] = Field(default_factory=list)
 
 
 class CreateSessionRequest(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,14 @@ from typing import AsyncGenerator
 
 from cryptography.fernet import Fernet
 
+# Ensure project package modules are importable when tests run without installation
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
 FERNET_KEY = Fernet.generate_key().decode()
 os.environ.setdefault("TELEGRAM_BOT_TOKEN", "TEST_TOKEN")
 os.environ.setdefault("SECRETS_KEY", FERNET_KEY)


### PR DESCRIPTION
## Summary
- enrich admin API responses with detailed session data, provider encryption handling, and modern Pydantic config
- add admin session detail page and link along with bot handlers that stream conversation summaries to the user
- update configuration schema, participant metadata, and test bootstrap utilities for compatibility

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd89d2f48c8326b6be0d749c79a6db