### PR TITLE
Add dedicated Dockerfiles for api, bot, and worker services

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+*.egg-info/
+.env
+.env.*
+.git
+.gitignore
+.mypy_cache/
+.pytest_cache/
+.tox/
+build/
+dist/
+logs/

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential libffi-dev libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir .
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.bot
+++ b/Dockerfile.bot
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential libffi-dev libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir .
+
+CMD ["python", "bot.py"]

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential libffi-dev libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir .
+
+CMD ["celery", "-A", "worker.celery_app", "worker", "--loglevel=info"]

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import asyncio
+
+from bot.runner import main
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,10 @@ version: "3.9"
 
 services:
   api:
-    build: .
-    command: uvicorn admin.main:app --host 0.0.0.0 --port 8000 --reload
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+    command: uvicorn main:app --host 0.0.0.0 --port 8000
     env_file:
       - .env
     depends_on:
@@ -11,12 +13,12 @@ services:
       - redis
     ports:
       - "8000:8000"
-    volumes:
-      - .:/app
 
   bot:
-    build: .
-    command: python -m bot.runner
+    build:
+      context: .
+      dockerfile: Dockerfile.bot
+    command: python bot.py
     env_file:
       - .env
     depends_on:
@@ -24,8 +26,10 @@ services:
       - redis
 
   worker:
-    build: .
-    command: celery -A worker.celery_app worker -l info
+    build:
+      context: .
+      dockerfile: Dockerfile.worker
+    command: celery -A worker.celery_app worker --loglevel=info
     env_file:
       - .env
     depends_on:

--- a/main.py
+++ b/main.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from admin.main import app
+
+__all__ = ["app"]


### PR DESCRIPTION
## Summary
- add individual Dockerfiles for the API, bot, and worker services so they install dependencies and use the required commands
- expose simple entry points for uvicorn and the Telegram bot via new main.py and bot.py modules
- update docker-compose to build from the new Dockerfiles and add a Docker ignore list for smaller contexts

## Testing
- pytest -v

------
https://chatgpt.com/codex/tasks/task_e_68dd9574fd488326a10b5c2989c29df5