### PR TITLE
Enable streaming dialogue updates and improve stop handling

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import asyncio
+import json
+
 import httpx
 import pytest
 
@@ -71,3 +74,124 @@ async def test_full_session_flow(monkeypatch):
         response = await client.get(f"/api/sessions/{session_id}")
         assert response.status_code == 200
         assert response.json()["id"] == session_id
+
+
+@pytest.mark.asyncio
+async def test_streaming_session_flow(monkeypatch):
+    stub = ApiStubAdapter()
+
+    def adapter_factory(provider_type, api_key, model, **params):
+        return stub
+
+    monkeypatch.setattr(service_module, "create_adapter", adapter_factory)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        provider_payload = {
+            "name": "OpenAI",
+            "type": "openai",
+            "api_key": "key",
+            "model_id": "gpt",
+            "parameters": {},
+            "enabled": True,
+            "order_index": 0,
+        }
+        response = await client.post("/api/providers", json=provider_payload)
+        assert response.status_code == 201
+
+        personality_payload = {
+            "title": "Expert",
+            "instructions": "Будь экспертом",
+            "style": "Формально",
+        }
+        response = await client.post("/api/personalities", json=personality_payload)
+        assert response.status_code == 201
+
+        response = await client.post("/api/users", json={"telegram_id": 1, "username": "tester"})
+        assert response.status_code == 201
+
+        session_payload = {"user_id": 1, "topic": "ИИ в образовании", "max_rounds": 2}
+        response = await client.post("/api/sessions", json=session_payload)
+        assert response.status_code == 201
+        session_id = response.json()["id"]
+
+        events: list[dict] = []
+        async with client.stream(
+            "POST", f"/api/sessions/{session_id}/start", params={"stream": "true"}
+        ) as response:
+            assert response.status_code == 200
+            async for line in response.aiter_lines():
+                if not line:
+                    continue
+                events.append(json.loads(line))
+
+        message_events = [event for event in events if event.get("type") == "message"]
+        assert len(message_events) == 2
+        assert events[-1]["type"] == "session"
+        assert events[-1]["status"] == "finished"
+        assert events[-1]["current_round"] == 2
+
+
+@pytest.mark.asyncio
+async def test_stop_session_during_stream(monkeypatch):
+    class SlowStubAdapter(ApiStubAdapter):
+        async def complete(self, prompt, context):
+            self.counter += 1
+            await asyncio.sleep(0.05)
+            return f"Ответ API {self.counter}", {"prompt_tokens": 5, "completion_tokens": 5, "cost": 0.002}
+
+    stub = SlowStubAdapter()
+
+    def adapter_factory(provider_type, api_key, model, **params):
+        return stub
+
+    monkeypatch.setattr(service_module, "create_adapter", adapter_factory)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        provider_payload = {
+            "name": "OpenAI",
+            "type": "openai",
+            "api_key": "key",
+            "model_id": "gpt",
+            "parameters": {},
+            "enabled": True,
+            "order_index": 0,
+        }
+        response = await client.post("/api/providers", json=provider_payload)
+        assert response.status_code == 201
+        personality_payload = {
+            "title": "Expert",
+            "instructions": "Будь экспертом",
+            "style": "Формально",
+        }
+        response = await client.post("/api/personalities", json=personality_payload)
+        assert response.status_code == 201
+        response = await client.post("/api/users", json={"telegram_id": 2, "username": "tester"})
+        assert response.status_code == 201
+        session_payload = {"user_id": 2, "topic": "ИИ и этика", "max_rounds": 3}
+        response = await client.post("/api/sessions", json=session_payload)
+        session_id = response.json()["id"]
+
+        events: list[dict] = []
+
+        async def stop_soon():
+            await asyncio.sleep(0.01)
+            return await client.post(f"/api/sessions/{session_id}/stop")
+
+        stop_task = asyncio.create_task(stop_soon())
+        async with client.stream(
+            "POST", f"/api/sessions/{session_id}/start", params={"stream": "true"}
+        ) as response:
+            async for line in response.aiter_lines():
+                if not line:
+                    continue
+                events.append(json.loads(line))
+
+        stop_response = await stop_task
+        assert stop_response.status_code == 200
+        assert stop_response.json()["status"] == "stopped"
+        assert events[-1]["type"] == "session"
+        assert events[-1]["status"] == "stopped"
+        message_events = [event for event in events if event.get("type") == "message"]
+        assert len(message_events) <= 1


### PR DESCRIPTION
## Summary
- add streaming support to the session start API and expose incremental message events
- update the Telegram bot to consume the stream and surface each model reply while handling stop requests gracefully
- cover the new streaming and stop behaviour with dedicated API and orchestrator tests

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd980e68c88326a5b01f7f8189146a