### PR TITLE
Add admin CRUD forms and session management UI

### DIFF
--- a/admin/main.py
+++ b/admin/main.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
-from fastapi import Depends, FastAPI, Request
-from fastapi.responses import HTMLResponse
+import json
+
+from fastapi import Depends, FastAPI, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from admin.api import api_router
 from core.config import get_settings
 from core.db import AsyncSessionLocal, get_session
 from core.models import Personality, Provider, Session, Setting
+from core.security import get_secrets_manager
 from orchestrator.service import DialogueOrchestrator
 
 app = FastAPI(title="Roundtable AI")
@@ -40,28 +44,451 @@ async def admin_dashboard(request: Request, db: AsyncSession = Depends(get_sessi
 async def admin_providers(request: Request, db: AsyncSession = Depends(get_session)) -> HTMLResponse:
     result = await db.execute(select(Provider).order_by(Provider.order_index))
     providers = result.scalars().all()
-    return templates.TemplateResponse("providers.html", {"request": request, "title": "Провайдеры", "providers": providers})
+    return templates.TemplateResponse(
+        "providers.html",
+        {"request": request, "title": "Провайдеры", "providers": providers},
+    )
+
+
+def _provider_form_defaults() -> dict:
+    return {
+        "name": "",
+        "type": "",
+        "api_key": "",
+        "model_id": "",
+        "parameters": "{}",
+        "enabled": True,
+        "order_index": "0",
+    }
+
+
+def _provider_form_context(
+    request: Request,
+    *,
+    title: str,
+    action: str,
+    form_data: dict,
+    errors: list[str] | None = None,
+) -> dict:
+    return {
+        "request": request,
+        "title": title,
+        "form": form_data,
+        "form_action": action,
+        "errors": errors or [],
+    }
+
+
+@app.get("/admin/providers/new", response_class=HTMLResponse)
+async def admin_provider_new(request: Request) -> HTMLResponse:
+    context = _provider_form_context(
+        request,
+        title="Новый провайдер",
+        action="/admin/providers/new",
+        form_data=_provider_form_defaults(),
+    )
+    return templates.TemplateResponse("provider_form.html", context)
+
+
+async def _provider_from_form(
+    request: Request,
+    *,
+    existing: Provider | None = None,
+) -> tuple[dict, list[str], dict]:
+    form = await request.form()
+    form_data = {
+        "name": form.get("name", "").strip(),
+        "type": form.get("type", "").strip(),
+        "api_key": form.get("api_key", "").strip(),
+        "model_id": form.get("model_id", "").strip(),
+        "parameters": form.get("parameters", "").strip() or "{}",
+        "enabled": form.get("enabled") == "on",
+        "order_index": form.get("order_index", "0").strip() or "0",
+    }
+    errors: list[str] = []
+
+    if not form_data["name"]:
+        errors.append("Название обязательно для заполнения")
+    if not form_data["type"]:
+        errors.append("Тип обязателен для заполнения")
+    if not form_data["model_id"]:
+        errors.append("Model ID обязателен для заполнения")
+    if not existing and not form_data["api_key"]:
+        errors.append("API ключ обязателен для новых провайдеров")
+
+    try:
+        order_index = int(form_data["order_index"] or 0)
+    except ValueError:
+        errors.append("Порядок должен быть числом")
+        order_index = 0
+
+    try:
+        parameters = json.loads(form_data["parameters"] or "{}")
+        if not isinstance(parameters, dict):
+            raise ValueError
+    except ValueError:
+        errors.append("Параметры должны быть корректным JSON-объектом")
+        parameters = existing.parameters if existing else {}
+
+    payload = {
+        "name": form_data["name"],
+        "type": form_data["type"],
+        "api_key": form_data["api_key"],
+        "model_id": form_data["model_id"],
+        "parameters": parameters,
+        "enabled": form_data["enabled"],
+        "order_index": order_index,
+    }
+
+    return form_data, errors, payload
+
+
+@app.post("/admin/providers/new")
+async def admin_provider_create(request: Request, db: AsyncSession = Depends(get_session)) -> HTMLResponse:
+    form_data, errors, payload = await _provider_from_form(request)
+    if errors:
+        context = _provider_form_context(
+            request,
+            title="Новый провайдер",
+            action="/admin/providers/new",
+            form_data=form_data,
+            errors=errors,
+        )
+        return templates.TemplateResponse(
+            "provider_form.html",
+            context,
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    secrets = get_secrets_manager()
+    provider = Provider(
+        name=payload["name"],
+        type=payload["type"],
+        api_key_encrypted=secrets.encrypt(payload["api_key"]),
+        model_id=payload["model_id"],
+        parameters=payload["parameters"],
+        enabled=payload["enabled"],
+        order_index=payload["order_index"],
+    )
+    db.add(provider)
+    await db.commit()
+    return RedirectResponse("/admin/providers", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.get("/admin/providers/{provider_id}/edit", response_class=HTMLResponse)
+async def admin_provider_edit(
+    provider_id: int, request: Request, db: AsyncSession = Depends(get_session)
+) -> HTMLResponse:
+    provider = await db.get(Provider, provider_id)
+    if not provider:
+        raise HTTPException(status_code=404, detail="Provider not found")
+    secrets = get_secrets_manager()
+    try:
+        api_key = secrets.decrypt(provider.api_key_encrypted)
+    except ValueError:
+        api_key = ""
+    form_data = {
+        "name": provider.name,
+        "type": provider.type,
+        "api_key": api_key,
+        "model_id": provider.model_id,
+        "parameters": json.dumps(provider.parameters or {}, ensure_ascii=False, indent=2),
+        "enabled": provider.enabled,
+        "order_index": str(provider.order_index),
+    }
+    context = _provider_form_context(
+        request,
+        title=f"Редактирование провайдера {provider.name}",
+        action=f"/admin/providers/{provider_id}/edit",
+        form_data=form_data,
+    )
+    return templates.TemplateResponse("provider_form.html", context)
+
+
+@app.post("/admin/providers/{provider_id}/edit")
+async def admin_provider_update(
+    provider_id: int, request: Request, db: AsyncSession = Depends(get_session)
+) -> HTMLResponse:
+    provider = await db.get(Provider, provider_id)
+    if not provider:
+        raise HTTPException(status_code=404, detail="Provider not found")
+
+    form_data, errors, payload = await _provider_from_form(request, existing=provider)
+    if errors:
+        context = _provider_form_context(
+            request,
+            title=f"Редактирование провайдера {provider.name}",
+            action=f"/admin/providers/{provider_id}/edit",
+            form_data=form_data,
+            errors=errors,
+        )
+        return templates.TemplateResponse(
+            "provider_form.html",
+            context,
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    secrets = get_secrets_manager()
+    provider.name = payload["name"]
+    provider.type = payload["type"]
+    provider.model_id = payload["model_id"]
+    provider.parameters = payload["parameters"]
+    provider.enabled = payload["enabled"]
+    provider.order_index = payload["order_index"]
+    if payload["api_key"]:
+        provider.api_key_encrypted = secrets.encrypt(payload["api_key"])
+    await db.commit()
+    return RedirectResponse("/admin/providers", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.post("/admin/providers/{provider_id}/delete")
+async def admin_provider_delete(provider_id: int, db: AsyncSession = Depends(get_session)) -> RedirectResponse:
+    provider = await db.get(Provider, provider_id)
+    if provider:
+        await db.delete(provider)
+        await db.commit()
+    return RedirectResponse("/admin/providers", status_code=status.HTTP_303_SEE_OTHER)
 
 
 @app.get("/admin/personalities", response_class=HTMLResponse)
 async def admin_personalities(request: Request, db: AsyncSession = Depends(get_session)) -> HTMLResponse:
     result = await db.execute(select(Personality).order_by(Personality.title))
     personalities = result.scalars().all()
-    return templates.TemplateResponse("personalities.html", {"request": request, "title": "Персоналии", "personalities": personalities})
+    return templates.TemplateResponse(
+        "personalities.html",
+        {
+            "request": request,
+            "title": "Персоналии",
+            "personalities": personalities,
+        },
+    )
+
+
+def _personality_form_context(
+    request: Request,
+    *,
+    title: str,
+    action: str,
+    form_data: dict,
+    errors: list[str] | None = None,
+) -> dict:
+    return {
+        "request": request,
+        "title": title,
+        "form": form_data,
+        "form_action": action,
+        "errors": errors or [],
+    }
+
+
+@app.get("/admin/personalities/new", response_class=HTMLResponse)
+async def admin_personality_new(request: Request) -> HTMLResponse:
+    form_data = {"title": "", "instructions": "", "style": ""}
+    context = _personality_form_context(
+        request,
+        title="Новая персоналия",
+        action="/admin/personalities/new",
+        form_data=form_data,
+    )
+    return templates.TemplateResponse("personality_form.html", context)
+
+
+async def _personality_from_form(request: Request) -> tuple[dict, list[str]]:
+    form = await request.form()
+    form_data = {
+        "title": form.get("title", "").strip(),
+        "instructions": form.get("instructions", "").strip(),
+        "style": form.get("style", "").strip(),
+    }
+    errors: list[str] = []
+    if not form_data["title"]:
+        errors.append("Название обязательно для заполнения")
+    if not form_data["instructions"]:
+        errors.append("Инструкции обязательны для заполнения")
+    return form_data, errors
+
+
+@app.post("/admin/personalities/new")
+async def admin_personality_create(request: Request, db: AsyncSession = Depends(get_session)) -> HTMLResponse:
+    form_data, errors = await _personality_from_form(request)
+    if errors:
+        context = _personality_form_context(
+            request,
+            title="Новая персоналия",
+            action="/admin/personalities/new",
+            form_data=form_data,
+            errors=errors,
+        )
+        return templates.TemplateResponse(
+            "personality_form.html",
+            context,
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    personality = Personality(**form_data)
+    db.add(personality)
+    await db.commit()
+    return RedirectResponse("/admin/personalities", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.get("/admin/personalities/{personality_id}/edit", response_class=HTMLResponse)
+async def admin_personality_edit(
+    personality_id: int, request: Request, db: AsyncSession = Depends(get_session)
+) -> HTMLResponse:
+    personality = await db.get(Personality, personality_id)
+    if not personality:
+        raise HTTPException(status_code=404, detail="Personality not found")
+    form_data = {
+        "title": personality.title,
+        "instructions": personality.instructions,
+        "style": personality.style or "",
+    }
+    context = _personality_form_context(
+        request,
+        title=f"Редактирование персоналии {personality.title}",
+        action=f"/admin/personalities/{personality_id}/edit",
+        form_data=form_data,
+    )
+    return templates.TemplateResponse("personality_form.html", context)
+
+
+@app.post("/admin/personalities/{personality_id}/edit")
+async def admin_personality_update(
+    personality_id: int, request: Request, db: AsyncSession = Depends(get_session)
+) -> HTMLResponse:
+    personality = await db.get(Personality, personality_id)
+    if not personality:
+        raise HTTPException(status_code=404, detail="Personality not found")
+
+    form_data, errors = await _personality_from_form(request)
+    if errors:
+        context = _personality_form_context(
+            request,
+            title=f"Редактирование персоналии {personality.title}",
+            action=f"/admin/personalities/{personality_id}/edit",
+            form_data=form_data,
+            errors=errors,
+        )
+        return templates.TemplateResponse(
+            "personality_form.html",
+            context,
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    personality.title = form_data["title"]
+    personality.instructions = form_data["instructions"]
+    personality.style = form_data["style"] or None
+    await db.commit()
+    return RedirectResponse("/admin/personalities", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.post("/admin/personalities/{personality_id}/delete")
+async def admin_personality_delete(
+    personality_id: int, db: AsyncSession = Depends(get_session)
+) -> RedirectResponse:
+    personality = await db.get(Personality, personality_id)
+    if personality:
+        await db.delete(personality)
+        await db.commit()
+    return RedirectResponse("/admin/personalities", status_code=status.HTTP_303_SEE_OTHER)
 
 
 @app.get("/admin/sessions", response_class=HTMLResponse)
 async def admin_sessions(request: Request, db: AsyncSession = Depends(get_session)) -> HTMLResponse:
-    result = await db.execute(select(Session).order_by(Session.created_at.desc()))
-    sessions = result.scalars().all()
-    return templates.TemplateResponse("sessions.html", {"request": request, "title": "Сессии", "sessions": sessions})
+    result = await db.execute(
+        select(Session)
+        .options(
+            selectinload(Session.messages),
+            selectinload(Session.user),
+        )
+        .order_by(Session.created_at.desc())
+    )
+    sessions = result.scalars().unique().all()
+    return templates.TemplateResponse(
+        "sessions.html",
+        {
+            "request": request,
+            "title": "Сессии",
+            "sessions": sessions,
+        },
+    )
+
+
+@app.post("/admin/sessions/{session_id}/stop")
+async def admin_stop_session(session_id: int, db: AsyncSession = Depends(get_session)) -> RedirectResponse:
+    orchestrator = DialogueOrchestrator(db)
+    await orchestrator.stop_session(session_id)
+    await db.commit()
+    return RedirectResponse("/admin/sessions", status_code=status.HTTP_303_SEE_OTHER)
 
 
 @app.get("/admin/settings", response_class=HTMLResponse)
 async def admin_settings(request: Request, db: AsyncSession = Depends(get_session)) -> HTMLResponse:
-    result = await db.execute(select(Setting))
+    result = await db.execute(select(Setting).order_by(Setting.key))
     settings = result.scalars().all()
-    return templates.TemplateResponse("settings.html", {"request": request, "title": "Настройки", "settings": settings})
+    return templates.TemplateResponse(
+        "settings.html",
+        {
+            "request": request,
+            "title": "Настройки",
+            "settings": settings,
+        },
+    )
+
+
+@app.post("/admin/settings/new")
+async def admin_setting_create(request: Request, db: AsyncSession = Depends(get_session)) -> HTMLResponse:
+    form = await request.form()
+    key = form.get("key", "").strip()
+    value = form.get("value", "").strip()
+    errors: list[str] = []
+    if not key:
+        errors.append("Ключ обязателен для заполнения")
+
+    if errors:
+        result = await db.execute(select(Setting).order_by(Setting.key))
+        settings = result.scalars().all()
+        return templates.TemplateResponse(
+            "settings.html",
+            {
+                "request": request,
+                "title": "Настройки",
+                "settings": settings,
+                "errors": errors,
+                "form": {"key": key, "value": value},
+            },
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    existing = await db.get(Setting, key)
+    if existing:
+        existing.value = value
+    else:
+        db.add(Setting(key=key, value=value))
+    await db.commit()
+    return RedirectResponse("/admin/settings", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.post("/admin/settings/{key}/update")
+async def admin_setting_update(
+    key: str, request: Request, db: AsyncSession = Depends(get_session)
+) -> RedirectResponse:
+    setting = await db.get(Setting, key)
+    if not setting:
+        raise HTTPException(status_code=404, detail="Setting not found")
+    form = await request.form()
+    setting.value = form.get("value", "").strip()
+    await db.commit()
+    return RedirectResponse("/admin/settings", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.post("/admin/settings/{key}/delete")
+async def admin_setting_delete(key: str, db: AsyncSession = Depends(get_session)) -> RedirectResponse:
+    setting = await db.get(Setting, key)
+    if setting:
+        await db.delete(setting)
+        await db.commit()
+    return RedirectResponse("/admin/settings", status_code=status.HTTP_303_SEE_OTHER)
 
 
 @app.on_event("startup")

--- a/admin/templates/personalities.html
+++ b/admin/templates/personalities.html
@@ -1,6 +1,18 @@
 {% extends "base.html" %}
 {% block content %}
-<h1 class="title">Персоналии</h1>
+<div class="level">
+    <div class="level-left">
+        <div class="level-item">
+            <h1 class="title">Персоналии</h1>
+        </div>
+    </div>
+    <div class="level-right">
+        <div class="level-item">
+            <a class="button is-primary" href="/admin/personalities/new">Добавить персоналию</a>
+        </div>
+    </div>
+</div>
+
 <table class="table is-striped is-fullwidth">
     <thead>
     <tr>
@@ -8,6 +20,7 @@
         <th>Название</th>
         <th>Инструкции</th>
         <th>Стиль</th>
+        <th></th>
     </tr>
     </thead>
     <tbody>
@@ -15,8 +28,18 @@
     <tr>
         <td>{{ personality.id }}</td>
         <td>{{ personality.title }}</td>
-        <td>{{ personality.instructions }}</td>
-        <td>{{ personality.style }}</td>
+        <td><pre style="white-space: pre-wrap">{{ personality.instructions }}</pre></td>
+        <td><pre style="white-space: pre-wrap">{{ personality.style }}</pre></td>
+        <td class="has-text-right">
+            <a class="button is-small is-info" href="/admin/personalities/{{ personality.id }}/edit">Редактировать</a>
+            <form method="post" action="/admin/personalities/{{ personality.id }}/delete" style="display:inline">
+                <button class="button is-small is-danger" type="submit" onclick="return confirm('Удалить персоналию?');">Удалить</button>
+            </form>
+        </td>
+    </tr>
+    {% else %}
+    <tr>
+        <td colspan="5" class="has-text-centered has-text-grey">Персоналий пока нет</td>
     </tr>
     {% endfor %}
     </tbody>

--- a/admin/templates/personality_form.html
+++ b/admin/templates/personality_form.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="title">{{ title }}</h1>
+{% if errors %}
+<div class="notification is-danger">
+    <ul>
+        {% for error in errors %}
+        <li>{{ error }}</li>
+        {% endfor %}
+    </ul>
+</div>
+{% endif %}
+<form method="post" action="{{ form_action }}">
+    <div class="field">
+        <label class="label">Название</label>
+        <div class="control">
+            <input class="input" type="text" name="title" value="{{ form.title }}" required>
+        </div>
+    </div>
+    <div class="field">
+        <label class="label">Инструкции</label>
+        <div class="control">
+            <textarea class="textarea" name="instructions" rows="6" required>{{ form.instructions }}</textarea>
+        </div>
+    </div>
+    <div class="field">
+        <label class="label">Стиль (опционально)</label>
+        <div class="control">
+            <textarea class="textarea" name="style" rows="4">{{ form.style }}</textarea>
+        </div>
+    </div>
+    <div class="field is-grouped">
+        <div class="control">
+            <button class="button is-primary" type="submit">Сохранить</button>
+        </div>
+        <div class="control">
+            <a class="button is-light" href="/admin/personalities">Отмена</a>
+        </div>
+    </div>
+</form>
+{% endblock %}

--- a/admin/templates/provider_form.html
+++ b/admin/templates/provider_form.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="title">{{ title }}</h1>
+{% if errors %}
+<div class="notification is-danger">
+    <ul>
+        {% for error in errors %}
+        <li>{{ error }}</li>
+        {% endfor %}
+    </ul>
+</div>
+{% endif %}
+<form method="post" action="{{ form_action }}">
+    <div class="field">
+        <label class="label">Название</label>
+        <div class="control">
+            <input class="input" type="text" name="name" value="{{ form.name }}" required>
+        </div>
+    </div>
+    <div class="field">
+        <label class="label">Тип</label>
+        <div class="control">
+            <input class="input" type="text" name="type" value="{{ form.type }}" required>
+        </div>
+    </div>
+    <div class="field">
+        <label class="label">API ключ</label>
+        <div class="control">
+            <input class="input" type="text" name="api_key" value="{{ form.api_key }}" {% if not form.api_key %}placeholder="Введите ключ"{% endif %}>
+        </div>
+        <p class="help">При редактировании можно оставить поле пустым, чтобы сохранить текущий ключ.</p>
+    </div>
+    <div class="field">
+        <label class="label">Model ID</label>
+        <div class="control">
+            <input class="input" type="text" name="model_id" value="{{ form.model_id }}" required>
+        </div>
+    </div>
+    <div class="field">
+        <label class="label">Параметры (JSON)</label>
+        <div class="control">
+            <textarea class="textarea" name="parameters" rows="6">{{ form.parameters }}</textarea>
+        </div>
+    </div>
+    <div class="field">
+        <label class="label">Порядок</label>
+        <div class="control">
+            <input class="input" type="number" name="order_index" value="{{ form.order_index }}">
+        </div>
+    </div>
+    <div class="field">
+        <label class="checkbox">
+            <input type="checkbox" name="enabled" {% if form.enabled %}checked{% endif %}>
+            Провайдер активен
+        </label>
+    </div>
+    <div class="field is-grouped">
+        <div class="control">
+            <button class="button is-primary" type="submit">Сохранить</button>
+        </div>
+        <div class="control">
+            <a class="button is-light" href="/admin/providers">Отмена</a>
+        </div>
+    </div>
+</form>
+{% endblock %}

--- a/admin/templates/providers.html
+++ b/admin/templates/providers.html
@@ -1,15 +1,28 @@
 {% extends "base.html" %}
 {% block content %}
-<h1 class="title">Провайдеры</h1>
+<div class="level">
+    <div class="level-left">
+        <div class="level-item">
+            <h1 class="title">Провайдеры</h1>
+        </div>
+    </div>
+    <div class="level-right">
+        <div class="level-item">
+            <a class="button is-primary" href="/admin/providers/new">Добавить провайдера</a>
+        </div>
+    </div>
+</div>
+
 <table class="table is-striped is-fullwidth">
     <thead>
     <tr>
         <th>ID</th>
         <th>Название</th>
         <th>Тип</th>
-        <th>Model</th>
+        <th>Модель</th>
         <th>Порядок</th>
-        <th>Вкл.</th>
+        <th>Включён</th>
+        <th></th>
     </tr>
     </thead>
     <tbody>
@@ -20,7 +33,17 @@
         <td>{{ provider.type }}</td>
         <td>{{ provider.model_id }}</td>
         <td>{{ provider.order_index }}</td>
-        <td>{{ provider.enabled }}</td>
+        <td>{% if provider.enabled %}Да{% else %}Нет{% endif %}</td>
+        <td class="has-text-right">
+            <a class="button is-small is-info" href="/admin/providers/{{ provider.id }}/edit">Редактировать</a>
+            <form method="post" action="/admin/providers/{{ provider.id }}/delete" style="display:inline">
+                <button class="button is-small is-danger" type="submit" onclick="return confirm('Удалить провайдера?');">Удалить</button>
+            </form>
+        </td>
+    </tr>
+    {% else %}
+    <tr>
+        <td colspan="7" class="has-text-centered has-text-grey">Провайдеров пока нет</td>
     </tr>
     {% endfor %}
     </tbody>

--- a/admin/templates/sessions.html
+++ b/admin/templates/sessions.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <h1 class="title">Сессии</h1>
-<table class="table is-striped is-fullwidth">
+<table class="table is-fullwidth is-striped">
     <thead>
     <tr>
         <th>ID</th>
@@ -10,17 +10,46 @@
         <th>Статус</th>
         <th>Раунды</th>
         <th>Завершено</th>
+        <th>История</th>
+        <th></th>
     </tr>
     </thead>
     <tbody>
     {% for session in sessions %}
     <tr>
         <td>{{ session.id }}</td>
-        <td>{{ session.user_id }}</td>
+        <td>
+            {{ session.user.username if session.user else session.user_id }}<br>
+            <small class="has-text-grey">ID: {{ session.user_id }}</small>
+        </td>
         <td>{{ session.topic }}</td>
         <td>{{ session.status }}</td>
         <td>{{ session.current_round }} / {{ session.max_rounds }}</td>
-        <td>{{ session.finished_at }}</td>
+        <td>{{ session.finished_at or "—" }}</td>
+        <td style="width: 280px;">
+            <details>
+                <summary>Показать ({{ session.messages|length }})</summary>
+                <div class="mt-2">
+                    {% for message in session.messages %}
+                    <div class="box" style="padding: 0.75rem;">
+                        <p><strong>{{ message.author_name }}</strong> <small class="has-text-grey">{{ message.author_type }} · {{ message.created_at }}</small></p>
+                        <p style="white-space: pre-wrap">{{ message.content }}</p>
+                    </div>
+                    {% else %}
+                    <p class="has-text-grey">Сообщений нет.</p>
+                    {% endfor %}
+                </div>
+            </details>
+        </td>
+        <td class="has-text-right">
+            <form method="post" action="/admin/sessions/{{ session.id }}/stop" style="display:inline">
+                <button class="button is-small is-warning" type="submit" {% if session.status != 'running' %}disabled{% endif %}>Остановить</button>
+            </form>
+        </td>
+    </tr>
+    {% else %}
+    <tr>
+        <td colspan="8" class="has-text-centered has-text-grey">Сессий пока нет</td>
     </tr>
     {% endfor %}
     </tbody>

--- a/admin/templates/settings.html
+++ b/admin/templates/settings.html
@@ -1,20 +1,79 @@
 {% extends "base.html" %}
 {% block content %}
 <h1 class="title">Настройки</h1>
+
+{% if errors %}
+<div class="notification is-danger">
+    <ul>
+        {% for error in errors %}
+        <li>{{ error }}</li>
+        {% endfor %}
+    </ul>
+</div>
+{% endif %}
+
+<div class="box">
+    <h2 class="subtitle is-5">Добавить или обновить настройку</h2>
+    <form method="post" action="/admin/settings/new">
+        <div class="columns">
+            <div class="column">
+                <div class="field">
+                    <label class="label">Ключ</label>
+                    <div class="control">
+                        <input class="input" type="text" name="key" value="{{ form.key if form else '' }}" placeholder="Например, PAYMENT_URL" required>
+                    </div>
+                </div>
+            </div>
+            <div class="column">
+                <div class="field">
+                    <label class="label">Значение</label>
+                    <div class="control">
+                        <input class="input" type="text" name="value" value="{{ form.value if form else '' }}" required>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="field is-grouped">
+            <div class="control">
+                <button class="button is-primary" type="submit">Сохранить</button>
+            </div>
+        </div>
+    </form>
+</div>
+
 <table class="table is-fullwidth">
     <thead>
     <tr>
         <th>Ключ</th>
         <th>Значение</th>
+        <th></th>
     </tr>
     </thead>
     <tbody>
     {% for item in settings %}
     <tr>
         <td>{{ item.key }}</td>
-        <td>{{ item.value }}</td>
+        <td>
+            <form method="post" action="/admin/settings/{{ item.key }}/update" class="is-flex" style="gap: 0.5rem; align-items: center;">
+                <input class="input" type="text" name="value" value="{{ item.value }}" style="flex: 1;">
+                <button class="button is-small is-link" type="submit">Обновить</button>
+            </form>
+        </td>
+        <td class="has-text-right">
+            <form method="post" action="/admin/settings/{{ item.key }}/delete" style="display:inline">
+                <button class="button is-small is-danger" type="submit" onclick="return confirm('Удалить настройку {{ item.key }}?');">Удалить</button>
+            </form>
+        </td>
+    </tr>
+    {% else %}
+    <tr>
+        <td colspan="3" class="has-text-centered has-text-grey">Настроек пока нет</td>
     </tr>
     {% endfor %}
     </tbody>
 </table>
+
+<div class="notification is-light">
+    <strong>PAYMENT_URL</strong> можно изменить прямо в таблице выше. Изменение сразу сохранится после нажатия «Обновить».
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add CRUD forms and routes for model providers and personalities in the admin panel
- enable inline creation, update, and deletion of settings including PAYMENT_URL edits
- show session message history and allow stopping running sessions from the admin UI

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'core' when loading tests)*

------
https://chatgpt.com/codex/tasks/task_e_68dda0af63d483269907febac18647cf