### PR TITLE
Add adapter, bot, and e2e dialogue tests

### DIFF
--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import pytest
+
+import httpx
+
+from adapters.deepseek_adapter import DeepSeekAdapter
+from adapters.openai_adapter import OpenAIAdapter
+
+
+class DummyResponse:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:  # pragma: no cover - no error path in tests
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class DummyClient:
+    def __init__(self, response: DummyResponse) -> None:
+        self._response = response
+        self.posts: list[tuple[str, dict | None, dict | None]] = []
+
+    async def __aenter__(self) -> "DummyClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def post(self, url: str, *, headers: dict | None = None, json: dict | None = None):
+        self.posts.append((url, headers, json))
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_openai_adapter_complete(monkeypatch: pytest.MonkeyPatch) -> None:
+    response_payload = {
+        "choices": [{"message": {"content": "Привет, мир!"}}],
+        "usage": {"prompt_tokens": 12, "completion_tokens": 6, "total_tokens": 18},
+    }
+    dummy_response = DummyResponse(response_payload)
+    dummy_client = DummyClient(dummy_response)
+
+    captured_kwargs: list[dict] = []
+
+    def client_factory(*args, **kwargs):
+        captured_kwargs.append(kwargs)
+        return dummy_client
+
+    monkeypatch.setattr(httpx, "AsyncClient", client_factory)
+
+    adapter = OpenAIAdapter(
+        api_key="secret", model="gpt-test", temperature=0.3, pricing={"prompt": 0.001, "completion": 0.002}
+    )
+    context = [{"role": "system", "content": "Контекст"}]
+
+    result, metadata = await adapter.complete("Скажи привет", context)
+
+    assert result == "Привет, мир!"
+    assert metadata == {
+        "prompt_tokens": 12,
+        "completion_tokens": 6,
+        "total_tokens": 18,
+        "cost": pytest.approx(0.024),
+    }
+
+    assert dummy_client.posts, "HTTP client must be called"
+    url, headers, payload = dummy_client.posts[0]
+    assert url == "https://api.openai.com/v1/chat/completions"
+    assert headers == {
+        "Authorization": "Bearer secret",
+        "Content-Type": "application/json",
+    }
+    assert payload["model"] == "gpt-test"
+    assert payload["messages"] == context + [{"role": "user", "content": "Скажи привет"}]
+    assert payload["temperature"] == 0.3
+    assert captured_kwargs == [{"timeout": 60}]
+
+
+@pytest.mark.asyncio
+async def test_deepseek_adapter_complete(monkeypatch: pytest.MonkeyPatch) -> None:
+    response_payload = {
+        "choices": [{"message": {"content": "Ответ DeepSeek"}}],
+        "usage": {"prompt_tokens": 8, "completion_tokens": 10, "total_tokens": 18},
+    }
+    dummy_response = DummyResponse(response_payload)
+    dummy_client = DummyClient(dummy_response)
+
+    captured_kwargs: list[dict] = []
+
+    def client_factory(*args, **kwargs):
+        captured_kwargs.append(kwargs)
+        return dummy_client
+
+    monkeypatch.setattr(httpx, "AsyncClient", client_factory)
+
+    adapter = DeepSeekAdapter(api_key="deep-secret", model="deep-model")
+    context = [{"role": "system", "content": "История"}]
+
+    result, metadata = await adapter.complete("Как дела?", context)
+
+    assert result == "Ответ DeepSeek"
+    expected_cost = 8 * 0.0000008 + 10 * 0.0000016
+    assert metadata == {
+        "prompt_tokens": 8,
+        "completion_tokens": 10,
+        "total_tokens": 18,
+        "cost": pytest.approx(expected_cost),
+    }
+
+    assert dummy_client.posts
+    url, headers, payload = dummy_client.posts[0]
+    assert url == "https://api.deepseek.com/chat/completions"
+    assert headers == {
+        "Authorization": "Bearer deep-secret",
+        "Content-Type": "application/json",
+    }
+    assert payload["model"] == "deep-model"
+    assert payload["messages"] == context + [{"role": "user", "content": "Как дела?"}]
+    assert payload["temperature"] == 0.7
+    assert captured_kwargs == [{"timeout": 60}]

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+
+from bot.handlers import stop_dialogue
+
+
+class DummyState:
+    def __init__(self, data: dict | None = None) -> None:
+        self._data = data or {}
+        self.cleared = False
+
+    async def get_data(self) -> dict:
+        return self._data
+
+    async def clear(self) -> None:
+        self.cleared = True
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.answers: list[str] = []
+
+    async def answer(self, text: str) -> None:
+        self.answers.append(text)
+
+
+@pytest.mark.asyncio
+async def test_stop_dialogue_with_active_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, dict]] = []
+
+    async def fake_api_post(path: str, payload: dict) -> dict:
+        calls.append((path, payload))
+        return {"status": "stopped"}
+
+    monkeypatch.setattr("bot.handlers.api_post", fake_api_post)
+
+    message = DummyMessage()
+    state = DummyState({"active_session_id": 55})
+
+    await stop_dialogue(message, state)
+
+    assert calls == [("/api/sessions/55/stop", {})]
+    assert state.cleared is True
+    assert message.answers[-1] == "Диалог остановлен."
+
+
+@pytest.mark.asyncio
+async def test_stop_dialogue_without_active_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def failing_api_post(*args, **kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("api_post must not be invoked when there is no active session")
+
+    monkeypatch.setattr("bot.handlers.api_post", failing_api_post)
+
+    message = DummyMessage()
+    state = DummyState()
+
+    await stop_dialogue(message, state)
+
+    assert message.answers == ["Сейчас нет активного обсуждения."]
+    assert state.cleared is False

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from core.models import Personality, Provider, Session, User
+from core.security import SecretsManager
+from orchestrator.service import DialogueOrchestrator
+
+
+@dataclass
+class E2ESettings:
+    max_rounds: int = 2
+    context_token_limit: int = 10_000
+    turn_timeout_sec: float = 1.0
+    max_session_tokens: int = 50_000
+    max_cost_per_session: float = 1_000.0
+
+
+@pytest.mark.asyncio
+async def test_e2e_two_round_dialogue(monkeypatch: pytest.MonkeyPatch, db_session) -> None:
+    secrets = SecretsManager()
+
+    providers = [
+        Provider(
+            name="OpenAI",
+            type="openai",
+            api_key_encrypted=secrets.encrypt("openai-key"),
+            model_id="gpt-test",
+            parameters={},
+            enabled=True,
+            order_index=0,
+        ),
+        Provider(
+            name="DeepSeek",
+            type="deepseek",
+            api_key_encrypted=secrets.encrypt("deepseek-key"),
+            model_id="deep-model",
+            parameters={},
+            enabled=True,
+            order_index=1,
+        ),
+    ]
+    personalities = [
+        Personality(title="Стратег", instructions="Думай стратегически", style="Формально"),
+        Personality(title="Философ", instructions="Будь философом", style="Вдохновенно"),
+    ]
+    user = User(telegram_id=99, username="e2e")
+
+    db_session.add_all(providers + personalities + [user])
+    await db_session.commit()
+
+    class AdapterStub:
+        def __init__(self, label: str) -> None:
+            self.label = label
+            self.calls: list[tuple[str, list[dict[str, str]]]] = []
+
+        async def complete(self, prompt: str, context: list[dict[str, str]]):
+            self.calls.append((prompt, context))
+            round_no = len(self.calls)
+            return f"{self.label} ответ {round_no}", {
+                "prompt_tokens": 5,
+                "completion_tokens": 7,
+                "cost": 0.0,
+            }
+
+    adapter_cache: dict[str, AdapterStub] = {}
+
+    def adapter_factory(provider_type: str, api_key: str, model: str, **params):
+        return adapter_cache.setdefault(provider_type, AdapterStub(provider_type))
+
+    monkeypatch.setattr("orchestrator.service.create_adapter", adapter_factory)
+
+    orchestrator = DialogueOrchestrator(db_session, settings=E2ESettings(), secrets=secrets)
+    session = await orchestrator.create_session(user_id=user.telegram_id, topic="Будущее ИИ", max_rounds=2)
+    await db_session.commit()
+
+    progress_rounds: list[int] = []
+
+    async def progress(message, round_number: int) -> None:
+        progress_rounds.append(round_number)
+
+    await orchestrator.start_session(session.id, progress_callback=progress)
+    await db_session.commit()
+
+    stored_session = await db_session.get(Session, session.id)
+    assert stored_session is not None
+    assert stored_session.status == "finished"
+    assert stored_session.current_round == 2
+
+    model_messages = [msg for msg in stored_session.messages if msg.author_type == "model"]
+    assert len(model_messages) == 4
+    assert [msg.author_name for msg in model_messages] == [
+        "OpenAI as Стратег",
+        "DeepSeek as Философ",
+        "OpenAI as Стратег",
+        "DeepSeek as Философ",
+    ]
+    assert [msg.content for msg in model_messages] == [
+        "openai ответ 1",
+        "deepseek ответ 1",
+        "openai ответ 2",
+        "deepseek ответ 2",
+    ]
+    assert progress_rounds == [1, 1, 2, 2]


### PR DESCRIPTION
## Summary
- add unit tests for the OpenAI and DeepSeek adapters using mocked HTTP clients
- add an end-to-end orchestrator test that verifies a two-round discussion between providers
- add bot handler tests covering the /stop command for active and inactive sessions

## Testing
- pytest -v

------
https://chatgpt.com/codex/tasks/task_e_68dda6e518788326a5d24aece702fb2f