### PR TITLE
Add Dockerfiles and compose targets for services

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,7 +1,9 @@
-FROM python:3.11-slim
+# syntax=docker/dockerfile:1.5
 
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+FROM python:3.11-slim AS builder
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
 
 WORKDIR /app
 
@@ -11,7 +13,25 @@ RUN apt-get update \
 
 COPY . .
 
-RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir .
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir --prefix=/install .
+
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libpq5 libffi8 libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /install /usr/local
+COPY --from=builder /app /app
+
+EXPOSE 8000
 
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.bot
+++ b/Dockerfile.bot
@@ -1,7 +1,9 @@
-FROM python:3.11-slim
+# syntax=docker/dockerfile:1.5
 
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+FROM python:3.11-slim AS builder
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
 
 WORKDIR /app
 
@@ -11,7 +13,23 @@ RUN apt-get update \
 
 COPY . .
 
-RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir .
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir --prefix=/install .
+
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libpq5 libffi8 libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /install /usr/local
+COPY --from=builder /app /app
 
 CMD ["python", "bot.py"]

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,7 +1,9 @@
-FROM python:3.11-slim
+# syntax=docker/dockerfile:1.5
 
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+FROM python:3.11-slim AS builder
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
 
 WORKDIR /app
 
@@ -11,7 +13,23 @@ RUN apt-get update \
 
 COPY . .
 
-RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir .
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir --prefix=/install .
+
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libpq5 libffi8 libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /install /usr/local
+COPY --from=builder /app /app
 
 CMD ["celery", "-A", "worker.celery_app", "worker", "--loglevel=info"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.api
+      target: runtime
     command: uvicorn main:app --host 0.0.0.0 --port 8000
     env_file:
       - .env
@@ -18,6 +19,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.bot
+      target: runtime
     command: python bot.py
     env_file:
       - .env
@@ -29,6 +31,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.worker
+      target: runtime
     command: celery -A worker.celery_app worker --loglevel=info
     env_file:
       - .env


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfiles for the API, bot, and worker services to prebuild dependencies and keep runtime images slim
- update docker-compose.yml to build the runtime stage for each service

## Testing
- not run (Docker is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ddfeff84248326a539f23566631fed