### PR TITLE
Implement runtime settings overrides and bot streaming updates

### DIFF
--- a/admin/api.py
+++ b/admin/api.py
@@ -373,15 +373,17 @@ class SettingResponse(BaseModel):
 
 @api_router.get("/settings/{key}", response_model=SettingResponse | None)
 async def get_setting_api(key: str, db: AsyncSession = Depends(get_session)) -> Setting | None:
-    value = await get_setting(db, key)
+    normalized_key = key.upper()
+    value = await get_setting(db, normalized_key)
     if value is None:
         return None
-    return Setting(key=key, value=value)
+    return Setting(key=normalized_key, value=value)
 
 
 @api_router.put("/settings/{key}", response_model=SettingResponse)
 async def set_setting_api(key: str, payload: SettingUpdate, db: AsyncSession = Depends(get_session)) -> Setting:
-    await set_setting(db, key, payload.value)
+    normalized_key = key.upper()
+    await set_setting(db, normalized_key, payload.value)
     await db.commit()
-    value = await get_setting(db, key)
-    return Setting(key=key, value=value or "")
+    value = await get_setting(db, normalized_key)
+    return Setting(key=normalized_key, value=value or "")

--- a/admin/main.py
+++ b/admin/main.py
@@ -439,7 +439,7 @@ async def admin_settings(request: Request, db: AsyncSession = Depends(get_sessio
 @app.post("/admin/settings/new")
 async def admin_setting_create(request: Request, db: AsyncSession = Depends(get_session)) -> HTMLResponse:
     form = await request.form()
-    key = form.get("key", "").strip()
+    key = form.get("key", "").strip().upper()
     value = form.get("value", "").strip()
     errors: list[str] = []
     if not key:
@@ -473,7 +473,8 @@ async def admin_setting_create(request: Request, db: AsyncSession = Depends(get_
 async def admin_setting_update(
     key: str, request: Request, db: AsyncSession = Depends(get_session)
 ) -> RedirectResponse:
-    setting = await db.get(Setting, key)
+    normalized_key = key.upper()
+    setting = await db.get(Setting, normalized_key)
     if not setting:
         raise HTTPException(status_code=404, detail="Setting not found")
     form = await request.form()
@@ -484,7 +485,8 @@ async def admin_setting_update(
 
 @app.post("/admin/settings/{key}/delete")
 async def admin_setting_delete(key: str, db: AsyncSession = Depends(get_session)) -> RedirectResponse:
-    setting = await db.get(Setting, key)
+    normalized_key = key.upper()
+    setting = await db.get(Setting, normalized_key)
     if setting:
         await db.delete(setting)
         await db.commit()

--- a/bot/api_client.py
+++ b/bot/api_client.py
@@ -16,7 +16,7 @@ async def api_post(path: str, json: dict[str, Any]) -> dict[str, Any]:
         return response.json()
 
 
-async def api_get(path: str) -> dict[str, Any]:
+async def api_get(path: str) -> Any:
     async with httpx.AsyncClient(timeout=60) as client:
         response = await client.get(f"{API_BASE}{path}")
         response.raise_for_status()

--- a/bot/states.py
+++ b/bot/states.py
@@ -3,3 +3,4 @@ from aiogram.fsm.state import State, StatesGroup
 
 class DialogueStates(StatesGroup):
     waiting_for_topic = State()
+    dialogue_running = State()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile.api
       target: runtime
-    command: >-
-      sh -c "alembic upgrade head &&
-      uvicorn main:app --host 0.0.0.0 --port 8000 --reload"
+    command: "sh -c \"alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8000 --reload\""
     env_file:
       - .env
     depends_on:
@@ -18,6 +16,16 @@ services:
         condition: service_started
     ports:
       - "8000:8000"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health')\"",
+        ]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
 
   bot:
     build:
@@ -29,7 +37,7 @@ services:
       - .env
     depends_on:
       api:
-        condition: service_started
+        condition: service_healthy
       redis:
         condition: service_started
 
@@ -42,6 +50,8 @@ services:
     env_file:
       - .env
     depends_on:
+      api:
+        condition: service_healthy
       redis:
         condition: service_started
       db:

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -4,7 +4,8 @@ import pytest
 from sqlalchemy import select
 
 from core import db as core_db
-from core.models import Personality, Provider
+from core.config import get_settings
+from core.models import Personality, Provider, Setting
 from core.security import SecretsManager
 from core.seed import seed_initial_data
 
@@ -20,6 +21,7 @@ async def test_seed_initial_data_creates_defaults(engine) -> None:
     async with core_db.AsyncSessionLocal() as session:
         providers = (await session.execute(select(Provider))).scalars().all()
         personalities = (await session.execute(select(Personality))).scalars().all()
+        payment_setting = await session.get(Setting, "PAYMENT_URL")
 
     provider_names = {provider.name for provider in providers}
     assert {"ChatGPT", "DeepSeek"}.issubset(provider_names)
@@ -35,3 +37,7 @@ async def test_seed_initial_data_creates_defaults(engine) -> None:
     }
     assert decrypted["ChatGPT"] == ""
     assert decrypted["DeepSeek"] == ""
+
+    settings = get_settings()
+    assert payment_setting is not None
+    assert payment_setting.value == str(settings.payment_url)


### PR DESCRIPTION
## Summary
- ensure Docker services wait for healthy dependencies and add API healthcheck
- allow the orchestrator to honour admin overrides for limits, tighten context compression, and log usage metadata
- stream model replies to Telegram users with a running state, pull the donate link from settings, and seed defaults including PAYMENT_URL
- normalize admin setting keys to uppercase and extend tests for runtime overrides and seeding behaviour

## Testing
- pytest -v

------
https://chatgpt.com/codex/tasks/task_e_68de0e65d0fc8326a8dff63dcc8b5eab