### PR TITLE
Restrict pytest discovery to top-level tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ ignore = ["D100", "D104", "D401"]
 [tool.pytest.ini_options]
 addopts = "-ra"
 asyncio_mode = "auto"
+testpaths = [
+    "tests",
+]
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary
- configure pytest to only discover tests from the root `tests` directory to avoid duplicate collections

## Testing
- pytest -v

------
https://chatgpt.com/codex/tasks/task_e_68de150e4e948326a93cc8c9f1f63a71