### PR TITLE
Update bot initialization for aiogram 3.7

### DIFF
--- a/bot/runner.py
+++ b/bot/runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 
 from aiogram import Bot, Dispatcher
+from aiogram.client.default import DefaultBotProperties
 from aiogram.fsm.storage.redis import RedisStorage, Redis
 
 from bot.handlers import router
@@ -13,7 +14,10 @@ async def main() -> None:
     settings = get_settings()
     redis = Redis.from_url(settings.redis_url)
     storage = RedisStorage(redis=redis)
-    bot = Bot(token=settings.telegram_bot_token, parse_mode="HTML")
+    bot = Bot(
+        token=settings.telegram_bot_token,
+        default=DefaultBotProperties(parse_mode="HTML"),
+    )
     dp = Dispatcher(storage=storage)
     dp.include_router(router)
     await dp.start_polling(bot)


### PR DESCRIPTION
## Summary
- switch the bot initialization to use DefaultBotProperties so parse mode works with aiogram 3.7+

## Testing
- pytest -v

------
https://chatgpt.com/codex/tasks/task_e_68de1d09ae608326bafd9ee2abe03b85