### PR TITLE
Configure async engine connection pooling options

### DIFF
--- a/core/db.py
+++ b/core/db.py
@@ -9,7 +9,18 @@ class Base(DeclarativeBase):
 
 
 settings = get_settings()
-engine = create_async_engine(settings.database_url, echo=False, future=True)
+
+
+ENGINE_OPTIONS = dict(
+    echo=False,
+    future=True,
+    pool_pre_ping=True,
+    pool_recycle=1800,
+    pool_size=10,
+    max_overflow=20,
+)
+
+engine = create_async_engine(settings.database_url, **ENGINE_OPTIONS)
 AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 
 

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 import asyncio
 from logging.config import fileConfig
 
-from sqlalchemy import pool
 from sqlalchemy.engine import Connection
-from sqlalchemy.ext.asyncio import async_engine_from_config
+from sqlalchemy.ext.asyncio import create_async_engine
 
 from alembic import context
 
 from core.config import get_settings
-from core.db import Base
+from core.db import Base, ENGINE_OPTIONS
 from core import models  # noqa: F401
 
 config = context.config
@@ -37,7 +36,7 @@ def do_run_migrations(connection: Connection) -> None:
 
 
 def run_migrations_online() -> None:
-    connectable = async_engine_from_config(config.get_section(config.config_ini_section, {}), prefix="sqlalchemy.", poolclass=pool.NullPool)
+    connectable = create_async_engine(settings.database_url, **ENGINE_OPTIONS)
 
     async def run_migrations() -> None:
         async with connectable.connect() as connection:


### PR DESCRIPTION
## Summary
- enable connection pooling on the async SQLAlchemy engine with pre-ping, recycling, and capacity limits
- reuse the same engine options in Alembic migrations to keep migrations aligned with the application runtime

## Testing
- pytest -v

------
https://chatgpt.com/codex/tasks/task_e_68de4667b744832688c51b5bf5e1f775